### PR TITLE
Ajusta e refina prompts de estilo e geração de CV

### DIFF
--- a/prompts/CV_STYLE_GUIDE.md
+++ b/prompts/CV_STYLE_GUIDE.md
@@ -3,31 +3,31 @@
 > O objetivo é anti-fadiga cognitiva: o recrutador valida o fit em 5 segundos lendo as âncoras em negrito.
 
 ## 1. RESUMO EXECUTIVO (3 a 4 linhas)
-- **Tese de Posicionamento:** Articule em prosa fluida por que você é a resposta exata para a dor da vaga, sem listar ferramentas soltas.
+- **Tom e Voz:** Primeira pessoa profissional ("Atuo com...", "Liderei...", "Tenho foco em..."). NUNCA fale em terceira pessoa ("conduziu", "o candidato").
+- **Tese de Posicionamento:** Articule em prosa fluida por que você é a resposta exata para a dor da vaga.
 - **Fórmula (3 frases conectadas em parágrafo único):**
   1. `[Senioridade + Especialidade focada na dor da vaga]`
   2. `[Maior entrega de impacto/escala com métrica factual do USER_PROFILE]`
-  3. `[Competência avançada ou experiência com IA/arquitetura conectada ao negócio]`
+  3. `[Competência avançada ou arquitetura aplicada conectada à vaga]`
 - **Regras Rígidas & Proibições:**
-  - **PROIBIDO usar rótulos/prefixos:** NUNCA escreva termos como `"Diferencial defensável:"`, `"Diferencial:"`, `"Tese:"`, `"Maior prova:"`, `"Métrica:"`. O texto deve fluir organicamente como um parágrafo natural de apresentação executiva.
-  - **PROIBIDO frases clichês:** Não inicie com "Desenvolvedor com experiência em...", "Profissional apaixonado por...", ou frases genéricas sem evidência de entrega.
+  - **PROIBIDO despejo de keywords:** NUNCA liste ferramentas soltas ou descontextualizadas da vaga no final do resumo.
+  - **PROIBIDO rótulos/prefixos:** NUNCA escreva `"Diferencial:"`, `"Tese:"`, `"Métrica:"`.
+  - **PROIBIDO clichês:** Não inicie com "Desenvolvedor com experiência em...", "Profissional apaixonado...".
 
-- **Contraste de Resumo:**
-  - ❌ *Robótico (Vazamento de Prompt):* `...baixa latência via renderização otimizada. Diferencial defensável: construção de sistemas agênticos com LLMs e Vercel AI SDK.`
-  - ✅ *Executivo (Prosa Fluida e Natural):* `...baixa latência via renderização otimizada e processamento client-side. Complementarmente, constrói sistemas agênticos com LLMs integrando Vercel AI SDK e RAG híbrido para acelerar fluxos e automações de produto.`
-
-## 2. ANATOMIA DO BULLET (STAR + Convicção Técnica)
-- **Fórmula Estrita:** `*Âncora em Negrito:* [Desafio/Gargalo] + [Decisão de Engenharia + Por que essa escolha] -> [Impacto/Resultado]`
+## 2. ANATOMIA DO BULLET (STAR + Convicção Técnica em One-Shot)
+- **Fórmula Obrigatória:** `*Âncora em Negrito:* [Desafio/Gargalo] + [Decisão de Engenharia + Por que essa escolha] -> [Impacto/Resultado]`
 - **Regras Rígidas:**
-  1. Início obrigatório com 2-4 palavras em negrito seguidas de dois pontos.
+  1. Início com 2-4 palavras em negrito com dois pontos e inicial maiúscula logo após: `*Âncora:* [Texto...]`.
   2. Proibido iniciar com verbo solto no passado ("Desenvolvi", "Migrei").
-  3. Toda decisão técnica deve expressar o *trade-off/motivação* (ex: desacoplar módulos, mitigar latência, garantir paridade).
-  4. Tamanho: Exatamente 1 a 2 linhas por bullet. Nunca ultrapassar 2 linhas.
+  3. Toda decisão técnica deve expressar o *trade-off/motivação* (ex: mitigar latência, desacoplar domínios, isolar estados).
+  4. Tamanho: Exatamente 1 a 2 linhas por bullet.
 
 - **Contraste Rápido:**
-  - ❌ *Commodity (Fraco):* `*Docker:* criei containers Docker para rodar os serviços da aplicação.`
-  - ✅ *Engenheiro (Forte):* `*Isolamento com Docker:* conteinerização de serviços para garantir paridade entre desenvolvimento e produção, eliminando gargalos de onboarding.`
+  - ❌ *Fraco:* `*Docker:* criei containers Docker para rodar os serviços da aplicação.`
+  - ✅ *Forte:* `*Isolamento com Docker:* conteinerização de microsserviços para garantir paridade entre ambientes, eliminando gargalos de onboarding.`
 
-## 3. ORÇAMENTO DE BULLETS (Teto Global: 14 a 17)
-- **Experiência Profissional:** 10 a 13 bullets no total.
-- **Projetos Pessoais (Destaques):** Máximo 1 ou 2 projetos relevantes à vaga (exatamente 2 bullets por projeto). Omitir os demais.
+## 3. ORÇAMENTO DE BULLETS (Teto Máximo, Não Meta)
+- **Regra Anti-Inflação:** O teto é um LIMITE MÁXIMO. NUNCA invente, duplique ou divida fatos para "bater meta" se o perfil tiver poucas experiências.
+- **Por Experiência:** Máximo de 2 a 4 bullets por cargo (nunca ultrapassar 4 bullets em uma mesma empresa).
+- **Projetos Pessoais:** Máximo 1 ou 2 projetos relevantes (exatamente 2 bullets por projeto).
+- **Teto Global:** 8 a 13 bullets no total do currículo.

--- a/prompts/generate_cv.md
+++ b/prompts/generate_cv.md
@@ -5,9 +5,9 @@ Sua missão é produzir o código Typst completo preenchendo o esqueleto base fo
 ## DIRETRIZES DE ENGENHARIA:
 1. **Fidelidade Factual Absoluta:** Utilize EXCLUSIVAMENTE dados do `USER_PROFILE.md`. NUNCA invente métricas, responsabilidades, tecnologias ou cursos.
 2. **Blindagem contra Alucinação de Gaps:** Os termos explicitamente marcados como GAPS não existem no histórico do candidato. É terminantemente PROIBIDO incluílos no currículo.
-3. **Template e Contatos:**
+3. **Template e Seções Obrigatórias:**
    - Inicie obrigatoriamente com: `#import "../templates/template.typ": columns-2, CV`
-   - Preencha o bloco `#show: CV.with(...)` com o nome e a lista de links/contatos extraídos da seção `## CONTACT` do `USER_PROFILE.md`, definindo o parâmetro `lang` conforme o idioma alvo.
-   - Mantenha a ordem padrão das seções do template no idioma fornecido (ex: Summary/Resumo, Experience/Experiência).
-4. **Curadoria de Projetos:** Inclua apenas os 1 ou 2 projetos selecionados. Os projetos não utilizados NÃO devem aparecer no código Typst.
+   - Preencha o bloco `#show: CV.with(...)` com o nome e contatos do candidato.
+   - Mantenha OBRIGATORIAMENTE TODAS as seções do template na ordem original: `RESUMO`, `EDUCAÇÃO`, `EXPERIÊNCIA PROFISSIONAL`, `PROJETOS PESSOAIS`, `LICENÇAS/CERTIFICAÇÕES` e `HABILIDADES E COMPETÊNCIAS`. NUNCA omita a seção de Educação.
+4. **Curadoria de Projetos:** Inclua apenas os 1 ou 2 projetos mais aderentes à vaga.
 5. **Submissão:** Submeta o código Typst final chamando a ferramenta `SubmitTypstCV`.


### PR DESCRIPTION
## O que mudou

Atualização dos prompts em `CV_STYLE_GUIDE.md` e `generate_cv.md` para deixar as regras mais claras, rígidas e alinhadas com a qualidade esperada do currículo.

### `CV_STYLE_GUIDE.md`
- Resumo executivo: reforça tom em **primeira pessoa profissional**, proíbe despejo de keywords e rótulos/prefixos, e ajusta a fórmula das 3 frases.
- Anatomia do bullet: deixa a fórmula obrigatória, exige inicial maiúscula após a âncora e mantém o foco em trade-off + impacto.
- Orçamento de bullets: muda de “meta” para **teto máximo** (anti-inflação), limita 2–4 bullets por experiência e reduz o teto global para 8–13.

### `generate_cv.md`
- Torna obrigatória a presença de **todas** as seções do template (incluindo Educação), na ordem original.
- Simplifica a instrução de preenchimento de contatos e reforça a curadoria de apenas 1–2 projetos aderentes à vaga.